### PR TITLE
old method deprecated as per substrate docs

### DIFF
--- a/workshop/add-pallet.md
+++ b/workshop/add-pallet.md
@@ -55,7 +55,7 @@ construct_runtime!(
 		Balances: pallet_balances,
 		TransactionPayment: pallet_transaction_payment,
 		Sudo: pallet_sudo,
-		SubstrateKitties: pallet_template, // <-- Update name here
+		SubstrateKitties: pallet_template::{Pallet, Call, Storage, Event<T>}, // <-- Update name here
 	}
 );
 ```


### PR DESCRIPTION
After getting the error 
the trait bound `RuntimeEvent: From<pallet_template::Event<Runtime>>` is not satisfied I Implemented by referring substrate documentation https://docs.substrate.io/build/events-and-errors/#exposing-events-to-your-runtime